### PR TITLE
Added multi-day forecast, aligned day/week forecast contexts

### DIFF
--- a/SlackResponseBlocks.php
+++ b/SlackResponseBlocks.php
@@ -41,7 +41,7 @@
             ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' X week`'],['type'=>'mrkdwn','text'=>'X can only be `1`']
           )
         );
-        $forecastNuanceBlock = array('type'=>'context','elements'=>[array('type'=>'mrkdwn','text'=>'When providing a numeric request (e.g. ` X [hours/days/week]`) the _hour-specific_ forecast will be returned based on the request time. For example, a 2-day request made at 5 p.m. will return the _hour_ forecast for 5 p.m. two days from now.')]);
+        $forecastNuanceBlock = array('type'=>'context','elements'=>[array('type'=>'mrkdwn','text'=>'When providing a numeric request (e.g. ` X hours`) the _hour-specific_ forecast will be returned based on the request time. However, an `X days` request made at 5 p.m. will return the _daily_ forecast for two days from now.')]);
         $forecastRelativeBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>'Relative keywords (`tomorrow`, `next`, and weekday names) can also be used:'));
         $forecastRelativeRangeBlock = array('type'=>'section','fields'=>
           array(['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' tomorrow`'],['type'=>'mrkdwn','text'=>'Display forecast for tomorrow'],

--- a/SlackResponseBlocks.php
+++ b/SlackResponseBlocks.php
@@ -34,17 +34,25 @@
       case 'forecast':
         // Forecast Range Detail
         $forecastHeaderBlock = array('type'=>'header','text'=>array('type'=>'plain_text','text'=>$bot_name . ' Help: Forecast Commands and Range','emoji'=>true));
-        $forecastDetailBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>'The ' . $bot_name . ' can respond to forecast inquiries _up to 10 days_ from the current time. This means arguments (`hours`, `days`, and `week`) should fall within the specified ranges. Arguments beyond this range will return a private error or display the current conditions.'));
+        $forecastDetailBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>'The ' . $bot_name . ' can respond to forecast inquiries _up to 10 days_ from the current time. Arguments (`hours`, `days`, and `week`) should fall within the specified ranges.'));
         $forecastRangeBlock = array('type'=>'section','fields'=>
           array(['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' X hour[s]`'],['type'=>'mrkdwn','text'=>'X can range `1` to `240`. Display the forecast for the specified hour'],
             ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' X day[s]`'],['type'=>'mrkdwn','text'=>'X can range `1` to `10`. Display the hour-specific forecast +X day[s]'],
-            ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' Saturday`'],['type'=>'mrkdwn','text'=>'`tomorrow` or weekday name. Display the "day" forecast.'],
             ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' X week`'],['type'=>'mrkdwn','text'=>'X can only be `1`']
           )
         );
-        $forecastNuanceBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>'It is important to understand that when providing a numeric request (`X` [hours/days/week]) the _hour-specific_ forecast will be returned based on the request time. For example, a 2-day request made at 5 p.m. will return the _hour_ forecast for 5 p.m. two days from now. Use the relative day name such as `tomorrow` or weekday names for the overall day forecast.'));
+        $forecastNuanceBlock = array('type'=>'context','elements'=>[array('type'=>'mrkdwn','text'=>'When providing a numeric request (e.g. ` X [hours/days/week]`) the _hour-specific_ forecast will be returned based on the request time. For example, a 2-day request made at 5 p.m. will return the _hour_ forecast for 5 p.m. two days from now.')]);
+        $forecastRelativeBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>'Relative keywords (`tomorrow`, `next`, and weekday names) can also be used:'));
+        $forecastRelativeRangeBlock = array('type'=>'section','fields'=>
+          array(['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' tomorrow`'],['type'=>'mrkdwn','text'=>'Display forecast for tomorrow'],
+          ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' Tuesday`'],['type'=>'mrkdwn','text'=>'Display forecast for Tuesday'],
+          ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' next 24 hours`'],['type'=>'mrkdwn','text'=>'Display forecasts for the next 24 hours'],
+            ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' next 10 days`'],['type'=>'mrkdwn','text'=>'Display forecasts for the next 10 days']
+          )
+        );
+        $forecastRelativeRangeDetailBlock = array('type'=>'context','elements'=>[array('type'=>'mrkdwn','text'=>'When providing a numeric relative request (e.g. `next X [hours/days/week]`) `X` must fall in the ranges identified above. Relative `day` and `week` requests will return daily forecasts for the period. Relative `hour` forecasts will generate dynamically-appropriate intervals for the period, generally not to exceed 10 individual forecasts per request.')]);
         // Build block response
-        $blocks = [$forecastHeaderBlock, $forecastDetailBlock, $forecastRangeBlock, $forecastNuanceBlock, $keywordPrivateBlock, $dividerBlock, $botVersionBlock];
+        $blocks = [$forecastHeaderBlock, $forecastDetailBlock, $forecastRangeBlock, $forecastNuanceBlock, $dividerBlock, $forecastRelativeBlock, $forecastRelativeRangeBlock, $forecastRelativeRangeDetailBlock, $keywordPrivateBlock, $dividerBlock, $botVersionBlock];
         break;
 
       case 'history':
@@ -58,9 +66,10 @@
             ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' dateString to dateString`'],['type'=>'mrkdwn','text'=>'Display summary for the submitted period']
           )
         );
-        $historyRelativeBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>'Relative keywords (`yesterday`, `last`, and `this`) can also be used:'));
+        $historyRelativeBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>'Relative keywords (`today`, `yesterday`, `last`, and `this`) can also be used:'));
         $historyRelativeRangeBlock = array('type'=>'section','fields'=>
-          array(['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' yesterday`'],['type'=>'mrkdwn','text'=>'Display daily summary for yesterday'],
+          array(['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' today`'],['type'=>'mrkdwn','text'=>'Display daily summary for yesterday'],
+            ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' yesterday`'],['type'=>'mrkdwn','text'=>'Display daily summary for yesterday'],
             ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' last week/month/year`'],['type'=>'mrkdwn','text'=>'Display summary for the requested period'],
             ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' this week/month/year`'],['type'=>'mrkdwn','text'=>'Display summary for the requested period (through the current day).']
           )
@@ -73,30 +82,41 @@
       default:
         // Generate generic help content
         // Opening Content
-        $openingBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>'The ' . $bot_name . ' responds to a number of arguments and keywords. When provided _no_ argument (e.g. `' . $bot_slashcommand . '`) the bot will respond with current conditions.'));
+        $openingBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>'The ' . $bot_name . ' responds to a number of arguments.'));
         // Command Examples
         $exampleCommandSection = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>'Example commands:'));
-        $exampleCommandBlock = array('type'=>'section','fields'=>
+        $exampleConditionsBlock = array('type'=>'section','fields'=>
           array(['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . '`'],['type'=>'mrkdwn','text'=>'Display current conditions'],
-            ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' Tuesday`'],['type'=>'mrkdwn','text'=>'Display the forecast for Tuesday'],
-            ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' 7 days`'],['type'=>'mrkdwn','text'=>'Display the forecast seven days from now'],
+            ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' now`'],['type'=>'mrkdwn','text'=>'Display current conditions'],
+            ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' private`'],['type'=>'mrkdwn','text'=>'Display current conditions privately']
+          )
+        );
+        $exampleForecastBlock = array('type'=>'section','fields'=>
+          array(['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' Tuesday`'],['type'=>'mrkdwn','text'=>'Display the forecast for Tuesday'],
+            ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' 8 hour`'],['type'=>'mrkdwn','text'=>'Display the forecast +8 hours from now'],
+            ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' 2 days`'],['type'=>'mrkdwn','text'=>'Display the forecast two days from now'],
+            ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' next 5 days`'],['type'=>'mrkdwn','text'=>'Display the five-day forecast']
+          )
+        );
+        $exampleHistoryBlock = array('type'=>'section','fields'=>
+          array(['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' today`'],['type'=>'mrkdwn','text'=>'Display summary for today'],
             ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' yesterday`'],['type'=>'mrkdwn','text'=>'Display summary for yesterday'],
             ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' last month`'],['type'=>'mrkdwn','text'=>'Display summary for last month']
           )
         );
         // Keyword Details
         $keywordHeaderBlock = array('type'=>'header','text'=>array('type'=>'plain_text','text'=>'Bot Keywords','emoji'=>true));
-        $keywordDetailBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>'The ' . $bot_name . ' responds to unique keywords unrelated to the weather conditions or forecast.'));
-        $keywordHelpCommandBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>'Several detailed help topics are supported:'));
+        $keywordDetailBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>'The ' . $bot_name . ' also responds to unique keywords:'));
+        $keywordHelpCommandBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>'Detailed `help` topics are also supported:'));
         $keywordHelpBlock = array('type'=>'section','fields'=>
           array(['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' help`'],['type'=>'mrkdwn','text'=>'Display this generic help information'],
-          ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' help conditions`'],['type'=>'mrkdwn','text'=>'Display help for obtaining current conditions'],
-          ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' help forecast`'],['type'=>'mrkdwn','text'=>'Display help for obtaining station forecasts'],
-          ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' help history`'],['type'=>'mrkdwn','text'=>'Display help for obtaining history summaries']
+          ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' help conditions`'],['type'=>'mrkdwn','text'=>'Help regarding current conditions'],
+          ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' help forecast`'],['type'=>'mrkdwn','text'=>'Help regarding station forecasts'],
+          ['type'=>'mrkdwn','text'=>'`' . $bot_slashcommand . ' help history`'],['type'=>'mrkdwn','text'=>'Help regarding history summaries']
           )
         );
         // Build block response
-        $blocks = [$helpHeaderBlock, $openingBlock, $exampleCommandSection, $exampleCommandBlock, $dividerBlock, $keywordHeaderBlock, $keywordDetailBlock, $keywordPrivateBlock, $keywordHelpCommandBlock, $keywordHelpBlock, $dividerBlock, $botSourceHeaderBlock, $botSourceDetailBlock, $dividerBlock, $botVersionBlock];
+        $blocks = [$helpHeaderBlock, $openingBlock, $exampleCommandSection, $exampleConditionsBlock, $exampleForecastBlock, $exampleHistoryBlock, $dividerBlock, $keywordHeaderBlock, $keywordDetailBlock, $keywordPrivateBlock, $keywordHelpCommandBlock, $keywordHelpBlock, $dividerBlock, $botSourceHeaderBlock, $botSourceDetailBlock, $dividerBlock, $botVersionBlock];
         break;
     }
     return $blocks;
@@ -153,6 +173,66 @@
     } else {
       $blocks = [$headerBlock, $conditionsBlock, $windBlock, $dividerBlock, $helpContextBlock];
     }
+
+    return $blocks;
+  }
+
+
+  function getForecastDayRangeBlocks($observations, $args = null) {
+    global $helpContextBlock, $dividerBlock, $slackConditionIcons;
+
+    $lastObs = count($observations) - 1;
+    // "Day" Forecast Block Content
+    $headerBlock = array('type'=>'header','text'=>array('type'=>'plain_text','text'=>'Forecast for ' . $observations[0]['timestamp'] . ' to ' . $observations[$lastObs]['timestamp'],'emoji'=>true));
+    $blocks[] = $headerBlock;
+
+    foreach ($observations as $observation) {
+      $dayHeaderBlock = array('type'=>'header','text'=>array('type'=>'plain_text','text'=>$slackConditionIcons[$observation['icon']] . ' ' . $observation['timestamp'] . ':','emoji'=>true));
+      $conditionsBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>$observation['conditions'] . ' with a high of ' . $observation['high_temperature'] . ' (low: ' . $observation['low_temperature'] . ').'));
+      $precipBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>'There is a ' . $observation['precip_probability'] . ' chance of ' . $observation['precip_type'] . '.'));
+      $sunBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>'Sunrise: ' . $observation['sunrise'] . ' | Sunset: ' . $observation['sunset'] . '.'));
+
+      $blocks[] = $dividerBlock;
+      $blocks[] = $dayHeaderBlock;
+      $blocks[] = $conditionsBlock;
+      if ($observation['precip_probability'] > 0) {
+        $blocks[] = $precipBlock;
+      }
+      $blocks[] = $sunBlock;
+    }
+
+    $blocks[] = $dividerBlock;
+    $blocks[] = $helpContextBlock;
+
+    return $blocks;
+  }
+
+
+  function getForecastHourRangeBlocks($observations, $args = null) {
+    global $helpContextBlock, $dividerBlock, $slackConditionIcons;
+
+    $lastObs = count($observations) - 1;
+    // "Hour" Forecast Block Content
+    $headerBlock = array('type'=>'header','text'=>array('type'=>'plain_text','text'=>'Forecast for ' . $observations[0]['timestamp'] . ' to ' . $observations[$lastObs]['timestamp'],'emoji'=>true));
+    $blocks[] = $headerBlock;
+
+    foreach ($observations as $observation) {
+      $hourHeaderBlock = array('type'=>'header','text'=>array('type'=>'plain_text','text'=>$slackConditionIcons[$observation['icon']] . ' ' . $observation['timestamp'] . ':','emoji'=>true));
+      $conditionsBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>$observation['conditions'] . ', ' . $observation['temperature'] . ' (feels like ' . $observation['feelsLike'] . ')'));
+      $precipBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>'There is a ' . $observation['precip_probability'] . ' chance of ' . $observation['precip_type'] . '.'));
+      $windBlock = array('type'=>'section','text'=>array('type'=>'mrkdwn','text'=>$observation['windDir'] . ' winds averaging ' . $observation['windAvg'] . '.'));
+
+      $blocks[] = $dividerBlock;
+      $blocks[] = $hourHeaderBlock;
+      $blocks[] = $conditionsBlock;
+      if ($observation['precip_probability'] > 0) {
+        $blocks[] = $precipBlock;
+      }
+      $blocks[] = $windBlock;
+    }
+
+    $blocks[] = $dividerBlock;
+    $blocks[] = $helpContextBlock;
 
     return $blocks;
   }

--- a/config/bot.php.example
+++ b/config/bot.php.example
@@ -11,7 +11,7 @@
   $bot_historyStarts = '2010-01-01';
 
   // Version vanity string and debug flag
-  $bot_version = '2021-01-18';
+  $bot_version = '2021-01-23';
   $debug_bot = false;
 
   // Sets the default API response to be the name of the Bot app, not the Bot user.


### PR DESCRIPTION
Added functionality to handle multi-day forecasts (hourly, daily, etc.) and realigned `X day` and `X week` forecast requests to return the matching _day_ forecasts rather than a specific _hour_ several days out. If asking for a 'day' (or alternatively a 'week' (out), user will now get a _day_ forecast.