### PR TITLE
Additional Slash Command Argument Handling and Bugfixes

### DIFF
--- a/SlackResponseBlocks.php
+++ b/SlackResponseBlocks.php
@@ -243,6 +243,24 @@
 
 
   /**
+   * getHourHistoryBlocks($observation, $args = null) - generate "hour" history block content of $observation
+   * 
+   * $observation - instance of TempestObservation
+   * $args - currently unused
+   * 
+   * @return array of block content payload
+   */
+  function getHourHistoryBlocks($observation, $args = null) {
+    global $helpContextBlock, $dividerBlock;
+
+    $blocks = $observation->getHourHistoryBlocks();
+    array_push($blocks, $dividerBlock, $helpContextBlock); 
+
+    return $blocks;
+  }
+
+
+  /**
    * getDayHistoryBlocks($observation, $args = null) - generate "day" history block content of $observation
    * 
    * $observation - instance of TempestObservation

--- a/TempestAPIFunctions.php
+++ b/TempestAPIFunctions.php
@@ -105,16 +105,17 @@
   }
 
   /**
-   * getStationObservationsByDay($date) - Grab the specified Tempest station's observations for the $date submitted (00:00:00 - 23:59:00)
+   * getStationObservationsByDay($date, $toFile = true) - Grab the specified Tempest station's observations for the $date submitted (00:00:00 - 23:59:00)
    * 
    * $date should be of format 'YYYY-MM-DD' to behave as designed; will likely report wonky results otherwise
    * 
    * Data resolution will _generally_ be 1 minute; however, Daylight Saving Time changes, specifically the "Fall" change, can cause a 1-day
    *  resolution change (to 5 minute) due to the additional "hour" worth of data in the range (pushing the total range > 24 hours).
    * 
-   * Writes JSON file to $tempestStationHistoryPath
+   * Writes JSON file to $tempestStationHistoryPath if $toFile == true (default behavior)
+   * @return array of observations if $toFile == false
    */
-  function getStationObservationsByDay($date) {
+  function getStationObservationsByDay($date, $toFile = true) {
     global $tempestObservationsUrl, $tempestStationHistoryPath;
 
 
@@ -136,7 +137,11 @@
     // should check some status stuff here to see if request was good...
     
     // Write out our station data
-    file_put_contents($tempestStationHistoryPath . $date . '.json', $json);
+    if ($toFile) {
+      file_put_contents($tempestStationHistoryPath . $date . '.json', $json);
+    } else {
+      return $stationObservations;
+    }
   }
 
   /**


### PR DESCRIPTION
Key bits addressed from #52:
* the `today` keyword will dynamically show the day's forecast (until 4 p.m.) or history (after 4 p.m.). User can override this behavior.
* when used, the `today` keyword will not write daily data to file, addressing the 'shorting' of daily data.

Key bits addressed from #41:
* negative hour requests (e.g. `/weather -36 hour`) will output the 1-hour interval history with the requested relative time as its midpoint. For example, at 5:45 p.m., a request for `-4 hour` (4:45 p.m.) will output history for the 4:15 p.m. (-30 minute) to 5:15 p.m. (+30 minute) interval.
* the `last` keyword for `day/days` or `hour/hours` will summarize the relative period appropriately.