### PR TITLE
Fixed path typos in moved job scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Edit each file as necessary for your bot. Note that as the bot goes into product
 
 Before the bot can properly respond to requests, two scripts must be manually invoked on the bot host to generate access lists and metadata:
 1. `php jobs/SlackUsers.php` will generate the "access list" of accounts in your Workspace, which is required to loosely "authenticate" a valid request.
-2. `php jobs/GenerateStationMetadata.php` will obtain the Tempest station metadata, which is required for all other Tempest API calls.
+2. `php jobs/GenerateTempestMetadata.php` will obtain the Tempest station metadata, which is required for all other Tempest API calls.
 
 Assuming both commands complete without issue, you can "install" the web request handler for your slash command. It is very important to understand that the `requesthandler/index.php` file is _not_ intended to be present at the same location as the rest of the bot source. `requesthandler/index.php` should be copied to the path you specified as the `Request URL` of your slash command and edit line 6 (`$botCodePath`) accordingly. This ensures separation between components of the bot (e.g. keeping bot source and keys not publicly-available).
 

--- a/jobs/CleanupHistory.php
+++ b/jobs/CleanupHistory.php
@@ -4,8 +4,9 @@
    * 
    * Intended to be called via cron on some routine (monthly, quarterly) interval, but not required for bot operation.
    */
+  $botCodePath = __DIR__ . '/../';
   // Grab the $tempestStationHistoryPath from bot configuration
-  include __DIR__ . '/config/tempest.php';
+  include $botCodePath . '/config/tempest.php';
   // Unlink/Delete each .json file at the $tempestStationHistoryPath
   array_map('unlink', glob("$tempestStationHistoryPath*.json"));
 ?>

--- a/jobs/GenerateTempestMetadata.php
+++ b/jobs/GenerateTempestMetadata.php
@@ -1,5 +1,6 @@
 <?php
-  require_once __DIR__ . '/TempestAPIFunctions.php';
+  $botCodePath = __DIR__ . '/../';
+  require_once $botCodePath . '/TempestAPIFunctions.php';
 
   updateStationMetadata();
 ?>

--- a/jobs/SlackUsers.php
+++ b/jobs/SlackUsers.php
@@ -1,6 +1,7 @@
 <?php
-  require_once __DIR__ . '/config/bot.php';
-  require_once __DIR__ . '/config/slack.php';
+  $botCodePath = __DIR__ . '/../';
+  require_once $botCodePath . '/config/bot.php';
+  require_once $botCodePath . '/config/slack.php';
 
   /**
    * GetSlackUsers() - function to obtain a list of Slack workspace users.
@@ -37,7 +38,7 @@
   // Grab the current user list and write it to file.
   $data = GetSlackUsers();
   if ($data) {
-    file_put_contents(__DIR__ . '/config/slackUsers.generated.php', '<?php return ' . var_export($data, true) . '; ?>');
+    file_put_contents($botCodePath . '/config/slackUsers.generated.php', '<?php return ' . var_export($data, true) . '; ?>');
   } else {
     print "Failed Request.\n";
   }


### PR DESCRIPTION
Not all scripts when they were moved to the `jobs/` path had their includes/requires paths changed. This fixes that situation and corrects a typo in the README.